### PR TITLE
ci: fix test step with cypress installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         run: pnpm i
       - name: build
         run: pnpm build
+      - name: Install Cypress
+        run: pnpm cypress install
       - name: Run cypress tests
         uses: cypress-io/github-action@30008f1458a5a2c97054bfe118fe33d75976c482
         with:


### PR DESCRIPTION
add install command for cypress, since updating CI steps using different cache handling it needed to be added